### PR TITLE
Fix/confluent s3 sink connector

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM confluentinc/cp-kafka-connect-base:6.1.0
+
+RUN confluent-hub install --no-prompt --verbose confluentinc/kafka-connect-s3:latest

--- a/Docker/commands.txt
+++ b/Docker/commands.txt
@@ -12,3 +12,6 @@ messages using curl:
 $ curl -s https://stream.meetup.com/2/rsvps | \
 	jq 'select(.venue != null) | .venue | {lon,lat,venue_id}' -c | \
 	kafka-avro-console-producer --bootstrap-server localhost:9092 --topic venues --property value.schema.id=1
+
+Creating connector
+$ curl -H 'Content-Type: application/json' -X POST -d @connector_S3SinkConnectorConnector_1_config.json http://localhost:8083/connectors

--- a/Docker/commands.txt
+++ b/Docker/commands.txt
@@ -5,3 +5,10 @@ docker-compose up -d
 docker build . -t my-custom-image:1.0.0
 FROM confluentinc/cp-kafka-connect-base:6.1.0
 RUN confluent-hub install confluentinc/kafka-connect-s3:5.5.3
+
+Generate a 'venues' topic, add the venues.avsc schema to it, and generate
+messages using curl:
+
+$ curl -s https://stream.meetup.com/2/rsvps | \
+	jq 'select(.venue != null) | .venue | {lon,lat,venue_id}' -c | \
+	kafka-avro-console-producer --bootstrap-server localhost:9092 --topic venues --property value.schema.id=1

--- a/Docker/commands.txt
+++ b/Docker/commands.txt
@@ -13,5 +13,9 @@ $ curl -s https://stream.meetup.com/2/rsvps | \
 	jq 'select(.venue != null) | .venue | {lon,lat,venue_id}' -c | \
 	kafka-avro-console-producer --bootstrap-server localhost:9092 --topic venues --property value.schema.id=1
 
+# NOTE: Requires AWS credentials
 Creating connector
 $ curl -H 'Content-Type: application/json' -X POST -d @connector_S3SinkConnectorConnector_1_config.json http://localhost:8083/connectors
+
+Expose AWS credentials to credentials helper by exporting the ACCESS_KEY and
+ACCESS_SECRET when running docker-compose

--- a/Docker/connector_S3SinkConnectorConnector_1_config.json
+++ b/Docker/connector_S3SinkConnectorConnector_1_config.json
@@ -1,0 +1,13 @@
+{
+  "name": "S3SinkConnectorConnector_1",
+  "config": {
+    "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+    "topics": "venues",
+    "format.class": "io.confluent.connect.s3.format.avro.AvroFormat",
+    "flush.size": "1000",
+    "s3.bucket.name": "<my bucket name>",
+    "s3.region": "eu-west-1",
+    "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+    "topics.dir": "<my object prefix>"
+  }
+}

--- a/Docker/docker-compose.override.yml
+++ b/Docker/docker-compose.override.yml
@@ -1,0 +1,43 @@
+version: "2"
+networks:
+  # This special network is configured so that the local metadata
+  # service can bind to the specific IP address that ECS uses
+  # in production
+  credentials_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: "169.254.170.0/24"
+          gateway: 169.254.170.1
+
+services:
+  # This container vends credentials to your containers
+  ecs-local-endpoints:
+    # The Amazon ECS Local Container Endpoints Docker Image
+    image: amazon/amazon-ecs-local-container-endpoints
+    volumes:
+      # Mount /var/run so we can access docker.sock and talk to Docker
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      # Share local AWS credentials with ECS service
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
+      AWS_SESSION_TOKEN: "${AWS_SESSION_TOKEN}"
+      AWS_DEFAULT_REGION: "eu-west-1"
+    networks:
+      credentials_network:
+        # This special IP address is recognized by the AWS SDKs and AWS CLI
+        ipv4_address: "169.254.170.2"
+
+  # Here we reference the application container that we are testing
+  # You can test multiple containers at a time, simply duplicate this section
+  # and customize it for each container, and give it a unique IP in 'credentials_network'.
+  connect:
+    depends_on:
+      - ecs-local-endpoints
+    networks:
+      - credentials_network
+      - default
+    environment:
+      AWS_DEFAULT_REGION: "eu-west-1"
+      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/creds"

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -179,8 +179,10 @@ services:
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
  
   connect:
-    image: confluentinc/cp-kafka-connect-base:6.0.1
+    build:
+      context: .
     container_name: kafka-connect
+    restart: always
     depends_on:
       - broker
       - schema-registry
@@ -205,17 +207,6 @@ services:
     # If you want to use the Confluent Hub installer to d/l component, but make them available
     # when running this offline, spin up the stack once and then run :
     #   docker cp kafka-connect:/usr/share/confluent-hub-components ./data/connect-jars
-    volumes:
-      - $PWD/data:/data
+    #volumes:
+      #- ./data:/data
     # In the command section, $ are replaced with $$ to avoid the error 'Invalid interpolation format for "command" option'
-    command:
-      - bash
-      - -c
-      - |
-        echo "Installing Connector"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-s3:5.5.3
-        #
-        echo "Launching Kafka Connect worker"
-        /etc/confluent/docker/run &
-        #
-        sleep infinity

--- a/Docker/venues.avsc
+++ b/Docker/venues.avsc
@@ -1,0 +1,20 @@
+{
+  "doc": "Sample schema to help you get started.",
+  "fields": [
+    {
+      "name": "lon",
+      "type": "double"
+    },
+    {
+      "name": "lat",
+      "type": "double"
+    },
+    {
+      "name": "venue_id",
+      "type": "long"
+    }
+  ],
+  "name": "value_venues",
+  "namespace": "com.mycorp.mynamespace",
+  "type": "record"
+}


### PR DESCRIPTION
Hey @Daniel-SG - here is an update to your docker-compose setup that makes it possible to write from a Kafka topic to an s3 bucket.

It does a couple of things:
- Build an image prior to running cluster with s3-connect installed
- Include a `docker-compose.override.yml` file to safely expose AWS credentials to the s3 connect container
- Add a sample topic schema and connect config to stream meetup venue data into kafka